### PR TITLE
Use TRAVIS_COMMIT for the filename of ShellSuite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ env:
     - BRANCH=master           VALIDATOR=shfmt       FLAGS=${FLAGS_SHFMT}      TAG=${TAG_SHFMT}
     - BRANCH=master           VALIDATOR=shfmt       FLAGS=${FLAGS_SHFMT}      TAG=latest
 script:
-  - curl -fsSL https://raw.githubusercontent.com/nemchik/ShellSuite/${BRANCH}/shellsuite.sh -o shellsuite.sh && bash shellsuite.sh -p "${PWD}" -v "${VALIDATOR}" -f " ${FLAGS}" -t "${TAG}"
+  - curl -fsSL https://raw.githubusercontent.com/nemchik/ShellSuite/${BRANCH}/shellsuite.sh -o shellsuite-${TRAVIS_COMMIT}.sh && bash shellsuite-${TRAVIS_COMMIT}.sh -p "${PWD}" -v "${VALIDATOR}" -f " ${FLAGS}" -t "${TAG}"
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Running from this repo:
 
 ```yaml
 script:
-  - curl -fsSL https://raw.githubusercontent.com/nemchik/ShellSuite/master/shellsuite.sh -o shellsuite.sh && bash shellsuite.sh -p "${PWD}" -v "bashate" -f " -i E006"
-  - curl -fsSL https://raw.githubusercontent.com/nemchik/ShellSuite/master/shellsuite.sh -o shellsuite.sh && bash shellsuite.sh -p "${PWD}" -v "shellcheck" -f " -x"
-  - curl -fsSL https://raw.githubusercontent.com/nemchik/ShellSuite/master/shellsuite.sh -o shellsuite.sh && bash shellsuite.sh -p "${PWD}" -v "shfmt" -f " -s -i 4 -ci -sr -d"
+  - curl -fsSL https://raw.githubusercontent.com/nemchik/ShellSuite/master/shellsuite.sh -o shellsuite-${TRAVIS_COMMIT}.sh && bash shellsuite-${TRAVIS_COMMIT}.sh -p "${PWD}" -v "bashate" -f " -i E006"
+  - curl -fsSL https://raw.githubusercontent.com/nemchik/ShellSuite/master/shellsuite.sh -o shellsuite-${TRAVIS_COMMIT}.sh && bash shellsuite-${TRAVIS_COMMIT}.sh -p "${PWD}" -v "shellcheck" -f " -x"
+  - curl -fsSL https://raw.githubusercontent.com/nemchik/ShellSuite/master/shellsuite.sh -o shellsuite-${TRAVIS_COMMIT}.sh && bash shellsuite-${TRAVIS_COMMIT}.sh -p "${PWD}" -v "shfmt" -f " -s -i 4 -ci -sr -d"
 ```
 
 Running from your own repo:


### PR DESCRIPTION
This should prevent ShellSuite from overwriting itself when testing itself. It's also not a bad practice in general for people to use with CI so that the name of the file is a bit random/temporary and does not risk overwriting something from their own repo.