### PR TITLE
Send tput stderr to null

### DIFF
--- a/shellsuite.sh
+++ b/shellsuite.sh
@@ -173,8 +173,8 @@ tcolor() {
             esac
         fi
         local COLOR_OUT
-        if [[ $(tput colors) -ge 8 ]]; then
-            COLOR_OUT=$(eval tput ${CAP:-} ${VAL:-})
+        if [[ $(tput colors 2> /dev/null) -ge 8 ]]; then
+            COLOR_OUT=$(eval tput ${CAP:-} ${VAL:-} 2> /dev/null)
         fi
         echo "${COLOR_OUT:-}"
     else


### PR DESCRIPTION
This prevents tput errors showing in the console when tput is not available.